### PR TITLE
Make messages published to message broker public to reuse them in santa

### DIFF
--- a/economy/contract.go
+++ b/economy/contract.go
@@ -146,13 +146,13 @@ type (
 		Value    bool
 	}
 
-	// | miningStarted is internal structure to hold notification message.
-	miningStarted struct {
+	// | MiningStarted is structure to hold notification message.
+	MiningStarted struct {
 		TS time.Time `json:"ts"`
 	}
 
-	// | stakingEnabled is internal structure to hold notification message.
-	stakingEnabled struct {
+	// | StakingEnabled is structure to hold notification message sent to message broker.
+	StakingEnabled struct {
 		TS time.Time `json:"ts"`
 		Staking
 	}

--- a/economy/contract.go
+++ b/economy/contract.go
@@ -73,6 +73,17 @@ type (
 		StartMining(context.Context, UserID) error
 		StartStaking(context.Context, UserID, Staking) error
 	}
+
+	// | MiningStarted is structure to hold notification message.
+	MiningStarted struct {
+		TS time.Time `json:"ts"`
+	}
+
+	// | StakingEnabled is structure to hold notification message sent to message broker.
+	StakingEnabled struct {
+		TS time.Time `json:"ts"`
+		Staking
+	}
 )
 
 const (
@@ -144,17 +155,6 @@ type (
 		//nolint:unused // Because it is used by the msgpack library for marshalling/unmarshalling.
 		_msgpack struct{} `msgpack:",asArray"`
 		Value    bool
-	}
-
-	// | MiningStarted is structure to hold notification message.
-	MiningStarted struct {
-		TS time.Time `json:"ts"`
-	}
-
-	// | StakingEnabled is structure to hold notification message sent to message broker.
-	StakingEnabled struct {
-		TS time.Time `json:"ts"`
-		Staking
 	}
 
 	// | repository implements the public API that this package exposes.

--- a/economy/staking.go
+++ b/economy/staking.go
@@ -75,7 +75,7 @@ func (e *economy) enableStaking(userID string, staking Staking, updatedAt time.T
 }
 
 func (e *economy) notifyStartStaking(ctx context.Context, userID UserID, staking Staking, startedAt time.Time) error {
-	m := stakingEnabled{
+	m := StakingEnabled{
 		TS:      startedAt,
 		Staking: staking,
 	}

--- a/economy/start_mining.go
+++ b/economy/start_mining.go
@@ -40,7 +40,7 @@ func (e *economy) StartMining(ctx context.Context, userID UserID) error {
 }
 
 func (e *economy) notifyStartMining(ctx context.Context, userID UserID, startedAt time.Time) error {
-	m := miningStarted{
+	m := MiningStarted{
 		TS: startedAt,
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.10 // indirect
-	google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3 // indirect
+	google.golang.org/genproto v0.0.0-20220518221133-4f43b3371335 // indirect
 	google.golang.org/grpc v1.46.2 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1510,8 +1510,8 @@ google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210108203827-ffc7fda8c3d7/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3 h1:q1kiSVscqoDeqTF27eQ2NnLLDmqF0I373qQNXYMy0fo=
-google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
+google.golang.org/genproto v0.0.0-20220518221133-4f43b3371335 h1:2D0OT6tPVdrQTOnVe1VQjfJPTED6EZ7fdJ/f6Db6OsY=
+google.golang.org/genproto v0.0.0-20220518221133-4f43b3371335/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=


### PR DESCRIPTION
We need to parse these messages in santa service to achieve tasks and levels to a user. 
But they are private for now, so make them public
[Task](https://www.notion.so/leftclick/Implement-Source-Processors-For-Achieving-Levels-Tasks-efea1ef41e7643eb8fa9fa5916af32d2)