### PR TITLE
fix calculation of active users count in case of session extension

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.10.0-rc.8 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect
-	github.com/bytedance/sonic v1.9.1 // indirect
+	github.com/bytedance/sonic v1.9.2 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
@@ -116,7 +116,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
 	github.com/quic-go/qtls-go1-19 v0.3.2 // indirect
-	github.com/quic-go/qtls-go1-20 v0.2.2 // indirect
+	github.com/quic-go/qtls-go1-20 v0.3.0 // indirect
 	github.com/quic-go/quic-go v0.36.0 // indirect
 	github.com/refraction-networking/utls v1.3.2 // indirect
 	github.com/rs/zerolog v1.29.1 // indirect
@@ -171,5 +171,7 @@ require (
 replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.6.19
 	github.com/docker/docker => github.com/docker/docker v20.10.3+incompatible
+	// https://github.com/quic-go/quic-go/issues/3907
+	github.com/quic-go/qtls-go1-20 => github.com/quic-go/qtls-go1-20 v0.2.2
 	github.com/testcontainers/testcontainers-go => github.com/testcontainers/testcontainers-go v0.15.0
 )

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/bsm/ginkgo/v2 v2.7.0 h1:ItPMPH90RbmZJt5GtkcNvIRuGEdwlBItdNVoyzaNQao=
 github.com/bsm/gomega v1.26.0 h1:LhQm+AFcgV2M0WyKroMASzAzCAJVpAxQXv4SaI9a69Y=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
-github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
-github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
+github.com/bytedance/sonic v1.9.2 h1:GDaNjuWSGu09guE9Oql0MSTNhNCLlWwO8y/xM5BzcbM=
+github.com/bytedance/sonic v1.9.2/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/tokenomics/adoption.go
+++ b/tokenomics/adoption.go
@@ -95,11 +95,15 @@ func (ms *MiningSession) detectIncrTotalActiveUsersKeys(repo *repository) []stri
 			repo.totalActiveUsersKey(*ms.StartedAt.Time) == repo.totalActiveUsersKey(*ms.PreviouslyEndedAt.Time)) {
 		start = start.Add(repo.cfg.AdoptionMilestoneSwitch.Duration)
 	}
+	start = start.Truncate(repo.cfg.AdoptionMilestoneSwitch.Duration)
+	end = end.Truncate(repo.cfg.AdoptionMilestoneSwitch.Duration)
 	for start.Before(end) {
 		keys = append(keys, repo.totalActiveUsersKey(start))
 		start = start.Add(repo.cfg.AdoptionMilestoneSwitch.Duration)
 	}
-	keys = append(keys, repo.totalActiveUsersKey(end))
+	if ms.PreviouslyEndedAt.IsNil() || repo.totalActiveUsersKey(end) != repo.totalActiveUsersKey(*ms.PreviouslyEndedAt.Time) {
+		keys = append(keys, repo.totalActiveUsersKey(end))
+	}
 
 	return keys
 }

--- a/tokenomics/adoption_test.go
+++ b/tokenomics/adoption_test.go
@@ -115,4 +115,28 @@ func TestDetectIncrTotalActiveUsersKeys(t *testing.T) {
 		repo.totalActiveUsersKey(now.Add(59 * cfg.AdoptionMilestoneSwitch.Duration)),
 		repo.totalActiveUsersKey(now.Add(60 * cfg.AdoptionMilestoneSwitch.Duration)),
 	}, actual)
+	offset := 80 * stdlibtime.Minute
+	ms = &MiningSession{
+		LastNaturalMiningStartedAt: time.New(now.Add(cfg.MiningSessionDuration.Min).Add(2*cfg.MiningSessionDuration.Max + 1).Add(offset)),
+		StartedAt:                  time.New(now.Add(cfg.MiningSessionDuration.Min).Add(cfg.MiningSessionDuration.Max + 1)),
+		EndedAt:                    time.New(now.Add(2 * cfg.MiningSessionDuration.Min).Add(2*cfg.MiningSessionDuration.Max + 1).Add(offset)),
+		PreviouslyEndedAt:          time.New(now.Add(cfg.MiningSessionDuration.Min).Add(cfg.MiningSessionDuration.Max)),
+		Extension:                  cfg.MiningSessionDuration.Min + offset,
+	}
+	actual = ms.detectIncrTotalActiveUsersKeys(repo)
+	assert.EqualValues(t, []string{
+		repo.totalActiveUsersKey(now.Add(61 * cfg.AdoptionMilestoneSwitch.Duration)),
+		repo.totalActiveUsersKey(now.Add(62 * cfg.AdoptionMilestoneSwitch.Duration)),
+		repo.totalActiveUsersKey(now.Add(63 * cfg.AdoptionMilestoneSwitch.Duration)),
+		repo.totalActiveUsersKey(now.Add(64 * cfg.AdoptionMilestoneSwitch.Duration)),
+		repo.totalActiveUsersKey(now.Add(65 * cfg.AdoptionMilestoneSwitch.Duration)),
+		repo.totalActiveUsersKey(now.Add(66 * cfg.AdoptionMilestoneSwitch.Duration)),
+		repo.totalActiveUsersKey(now.Add(67 * cfg.AdoptionMilestoneSwitch.Duration)),
+		repo.totalActiveUsersKey(now.Add(68 * cfg.AdoptionMilestoneSwitch.Duration)),
+		repo.totalActiveUsersKey(now.Add(69 * cfg.AdoptionMilestoneSwitch.Duration)),
+		repo.totalActiveUsersKey(now.Add(70 * cfg.AdoptionMilestoneSwitch.Duration)),
+		repo.totalActiveUsersKey(now.Add(71 * cfg.AdoptionMilestoneSwitch.Duration)),
+		repo.totalActiveUsersKey(now.Add(72 * cfg.AdoptionMilestoneSwitch.Duration)),
+		repo.totalActiveUsersKey(now.Add(73 * cfg.AdoptionMilestoneSwitch.Duration)),
+	}, actual)
 }

--- a/tokenomics/mining_sessions.go
+++ b/tokenomics/mining_sessions.go
@@ -320,5 +320,5 @@ func SessionNumber(date *time.Time, miningSessionResetDeadline stdlibtime.Durati
 }
 
 func (ms *MiningSession) duplGuardKey(repo *repository, guardType string) string {
-	return fmt.Sprintf("mining_session_dupl_guards:%v~%v~%v", guardType, ms.UserID, repo.sessionNumber(ms.StartedAt))
+	return fmt.Sprintf("mining_session_dupl_guards:%v~%v~%v", guardType, *ms.UserID, repo.sessionNumber(ms.LastNaturalMiningStartedAt))
 }


### PR DESCRIPTION
End key is incremented twice in some cases of extension.

In example for staging env (1m session duration):
initial session started at HH:MM:01
30 seconds passed (extension window)
user extends the session
new end time is HH:MM::31 (same HH:MM)
collide on child key

Same bug on eskimo: [#18](https://github.com/ice-blockchain/eskimo/pull/19)