### PR TITLE
fix significant balance increase after non-mining some time

### DIFF
--- a/miner/mining.go
+++ b/miner/mining.go
@@ -56,7 +56,7 @@ func mine(now *time.Time, usr *user, t0Ref, tMinus1Ref *referral) (updatedUser *
 			updatedUser.BalanceTotalSlashed = 0
 			updatedUser.BalanceTotalMinted = 0
 		}
-		if updatedUser.MiningSessionSoloEndedAt.After(*now.Time) && updatedUser.isAbsoluteZero() {
+		if updatedUser.MiningSessionSoloEndedAt.After(*now.Time) && (updatedUser.isAbsoluteZero() || updatedUser.reachedSlashingFloor()) {
 			updatedUser.BalanceLastUpdatedAt = updatedUser.MiningSessionSoloStartedAt
 		}
 	}


### PR DESCRIPTION
elapsed time is calculated based on balance last updated at, but it is in the past, and not updated when user is on slashing floor