### PR TITLE
Fixed total coins dates generation. Total coins cache update 1 time per day

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethereum/go-ethereum v1.14.6
 	github.com/goccy/go-json v0.10.3
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ice-blockchain/eskimo v1.365.0
+	github.com/ice-blockchain/eskimo v1.366.0
 	github.com/ice-blockchain/go-tarantool-client v0.0.0-20230327200757-4fc71fa3f7bb
 	github.com/ice-blockchain/wintr v1.144.0
 	github.com/imroc/req/v3 v3.43.7

--- a/go.sum
+++ b/go.sum
@@ -300,8 +300,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/ice-blockchain/eskimo v1.365.0 h1:0J8z7YX09dM1mrobwsAlC4S170CJriKZkKrl+5VpB+0=
-github.com/ice-blockchain/eskimo v1.365.0/go.mod h1:c2Yp7QwFzJvdrcbZSOmM4jY/Li6Wbo1LVnoouJrAe8g=
+github.com/ice-blockchain/eskimo v1.366.0 h1:brqw1rVWXhn7vtYUqzb8HguzjenMc9CSeYxbdidrBwk=
+github.com/ice-blockchain/eskimo v1.366.0/go.mod h1:c2Yp7QwFzJvdrcbZSOmM4jY/Li6Wbo1LVnoouJrAe8g=
 github.com/ice-blockchain/go-tarantool-client v0.0.0-20230327200757-4fc71fa3f7bb h1:8TnFP3mc7O+tc44kv2e0/TpZKnEVUaKH+UstwfBwRkk=
 github.com/ice-blockchain/go-tarantool-client v0.0.0-20230327200757-4fc71fa3f7bb/go.mod h1:ZsQU7i3mxhgBBu43Oev7WPFbIjP4TniN/b1UPNGbrq8=
 github.com/ice-blockchain/wintr v1.144.0 h1:YQE0olkPdSI6AOlw7r/j5jGI6uLciZQrvXFIkN4C4l4=

--- a/tokenomics/tokenomics.go
+++ b/tokenomics/tokenomics.go
@@ -51,7 +51,7 @@ func New(ctx context.Context, _ context.CancelFunc) Repository {
 	now := time.Now()
 	repo.mustInitTotalCoinsCache(ctx, now)
 
-	go repo.keepTotalCoinsCacheUpdated(ctx, now)
+	go repo.keepTotalCoinsCacheUpdated(ctx)
 	go repo.keepBlockchainDetailsCacheUpdated(ctx)
 
 	return repo
@@ -88,7 +88,7 @@ func StartProcessor(ctx context.Context, cancel context.CancelFunc) Processor {
 	now := time.Now()
 	prc.mustInitTotalCoinsCache(ctx, now)
 
-	go prc.keepTotalCoinsCacheUpdated(ctx, now)
+	go prc.keepTotalCoinsCacheUpdated(ctx)
 	go prc.keepBlockchainDetailsCacheUpdated(ctx)
 	prc.extraBonusStartDate = extrabonusnotifier.MustGetExtraBonusStartDate(ctx, prc.db)
 	prc.extraBonusIndicesDistribution = extrabonusnotifier.MustGetExtraBonusIndicesDistribution(ctx, prc.db)


### PR DESCRIPTION
Truncate(parent) values are used for total coin dates. Added history generation delta check for total coins dates generation (if delta wasn't passed -> get dates without today date, but add 1 extra day for endpoint results consistency). Update total coins cache 1 time per day instead of hourly as we have history generation per day format now.