### PR TITLE
fix issues with clickhouse save for stopped

### DIFF
--- a/miner/.testdata/application.yaml
+++ b/miner/.testdata/application.yaml
@@ -5,12 +5,14 @@ logger:
   encoder: console
   level: debug
 tokenomics:
+  slashingFloor: 1
   adoption:
     milestones: 7
     startingBaseMiningRate: 16
     durationBetweenMilestones: 168h
   miningSessionDuration:
     max: 24h
+    min: 12h
   extraBonuses:
     duration: 24h
   mining-boost:

--- a/miner/mining.go
+++ b/miner/mining.go
@@ -50,12 +50,14 @@ func mine(now *time.Time, usr *user, t0Ref, tMinus1Ref *referral) (updatedUser *
 		miningSessionRatio = 24.
 	}
 	if updatedUser.MiningSessionSoloEndedAt.Before(*now.Time) && (updatedUser.reachedSlashingFloor() || updatedUser.slashingDisabled()) {
+		fullSlashingDuration := stdlibtime.Duration(cfg.SlashingDaysCount * int64(miningSessionRatio) * int64(miningPeriod))
 		shouldGenerateHistory = (updatedUser.BalanceLastUpdatedAt.Year() != now.Year() ||
 			updatedUser.BalanceLastUpdatedAt.YearDay() != now.YearDay() ||
 			(cfg.Development && updatedUser.BalanceLastUpdatedAt.Minute() != now.Minute())) &&
 			((updatedUser.slashingDisabled() && updatedUser.BalanceLastUpdatedAt.After(*updatedUser.MiningSessionSoloEndedAt.Time) &&
 				updatedUser.BalanceLastUpdatedAt.Sub(*updatedUser.MiningSessionSoloEndedAt.Time) < cfg.MiningSessionDuration.Min) ||
 				(updatedUser.reachedSlashingFloor() &&
+					now.After(updatedUser.MiningSessionSoloEndedAt.Time.Add(fullSlashingDuration)) &&
 					now.Sub(*updatedUser.MiningSessionSoloEndedAt.Time) < stdlibtime.Duration((cfg.SlashingDaysCount+1)*int64(miningSessionRatio)*int64(miningPeriod))))
 
 		if shouldGenerateHistory {


### PR DESCRIPTION
fix issue with stopped users are being saved into clickhouse due to extra lastBalanceUpdatedAt updates on every shouldGenerateHistory calls, duplicated 500 bonus for the same referrals being received for T0 again cuz condition is not applied