### PR TITLE
Balance history parent-child structure adopted to month-day durations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,9 @@ require (
 	github.com/ethereum/go-ethereum v1.14.7
 	github.com/goccy/go-json v0.10.3
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ice-blockchain/eskimo v1.371.0
+	github.com/ice-blockchain/eskimo v1.372.0
 	github.com/ice-blockchain/go-tarantool-client v0.0.0-20230327200757-4fc71fa3f7bb
-	github.com/ice-blockchain/wintr v1.146.0
+	github.com/ice-blockchain/wintr v1.147.0
 	github.com/imroc/req/v3 v3.43.7
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pkg/errors v0.9.1
@@ -63,7 +63,7 @@ require (
 	github.com/consensys/bavard v0.1.13 // indirect
 	github.com/consensys/gnark-crypto v0.12.1 // indirect
 	github.com/containerd/cgroups/v3 v3.0.3 // indirect
-	github.com/containerd/containerd v1.7.19 // indirect
+	github.com/containerd/containerd v1.7.20 // indirect
 	github.com/containerd/continuity v0.4.3 // indirect
 	github.com/containerd/errdefs v0.1.0 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c // indirect

--- a/go.sum
+++ b/go.sum
@@ -303,12 +303,12 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/ice-blockchain/eskimo v1.371.0 h1:o9acbUNUZ80U7CLyzrQyd2T67O/92+a8jiut3BtTpV0=
-github.com/ice-blockchain/eskimo v1.371.0/go.mod h1:7m6dFwOIi3aSAdPBJa2nJKjaEr1QDXXDVs4D3w+m7c4=
+github.com/ice-blockchain/eskimo v1.372.0 h1:T5JfwtVMn3ep/1NW98sUZ99nRKOSKHgEUT+dtQk/T/w=
+github.com/ice-blockchain/eskimo v1.372.0/go.mod h1:etbbw8VRonltuR2fq4Rviput/FAItkatddbzj+eGxY8=
 github.com/ice-blockchain/go-tarantool-client v0.0.0-20230327200757-4fc71fa3f7bb h1:8TnFP3mc7O+tc44kv2e0/TpZKnEVUaKH+UstwfBwRkk=
 github.com/ice-blockchain/go-tarantool-client v0.0.0-20230327200757-4fc71fa3f7bb/go.mod h1:ZsQU7i3mxhgBBu43Oev7WPFbIjP4TniN/b1UPNGbrq8=
-github.com/ice-blockchain/wintr v1.146.0 h1:bYkbImnMYNYVcDftwBmAV0NbcHJIcP+J7a86HeJnTA8=
-github.com/ice-blockchain/wintr v1.146.0/go.mod h1:CgbY1UEyIx//+tM57Hz72Jd28UOs5tpOlJOByyQhi2c=
+github.com/ice-blockchain/wintr v1.147.0 h1:VQxvK3FWFIbm+X6obrecx7n07cBZoQDf/dQX8gfCcTc=
+github.com/ice-blockchain/wintr v1.147.0/go.mod h1:sVnoMxZc86JFoao4Beva7Z2EbNLhX8XlWsAeWNwfbCE=
 github.com/imroc/req/v3 v3.43.7 h1:dOcNb9n0X83N5/5/AOkiU+cLhzx8QFXjv5MhikazzQA=
 github.com/imroc/req/v3 v3.43.7/go.mod h1:SQIz5iYop16MJxbo8ib+4LnostGCok8NQf8ToyQc2xA=
 github.com/ip2location/ip2location-go/v9 v9.7.0 h1:ipwl67HOWcrw+6GOChkEXcreRQR37NabqBd2ayYa4Q0=

--- a/tokenomics/balance_test.go
+++ b/tokenomics/balance_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ice-blockchain/wintr/time"
 )
 
-func TestCalculateDates_Limit24_Offset0_Factor1(t *testing.T) {
+func TestCalculateDates_Factor1(t *testing.T) {
 	t.Parallel()
 	repo := &repository{cfg: &Config{
 		GlobalAggregationInterval: struct {
@@ -28,103 +28,46 @@ func TestCalculateDates_Limit24_Offset0_Factor1(t *testing.T) {
 
 	limit := uint64(24)
 	offset := uint64(0)
-	start := time.New(stdlibtime.Date(2023, 6, 5, 5, 15, 10, 1, stdlibtime.UTC))
+	start := time.New(stdlibtime.Date(2023, 6, 6, 5, 15, 10, 1, stdlibtime.UTC))
 	end := time.New(stdlibtime.Date(2023, 6, 7, 5, 15, 10, 1, stdlibtime.UTC))
 	factor := stdlibtime.Duration(1)
 
 	dates, notBeforeTime, notAfterTime := repo.calculateDates(limit, offset, start, end, factor)
-	assert.Len(t, dates, 1)
+	assert.Len(t, dates, 30)
+	assert.Equal(t, start, notBeforeTime)
+	assert.Equal(t, end, notAfterTime)
 
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC)), notBeforeTime)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, stdlibtime.UTC)), notAfterTime)
-
-	expectedStart := time.New(stdlibtime.Date(2023, 6, 5, 5, 0, 0, 0, stdlibtime.UTC))
 	expected := []stdlibtime.Time{
-		expectedStart.Time.Truncate(24 * stdlibtime.Hour),
-	}
-	assert.EqualValues(t, expected, dates)
-
-}
-
-func TestCalculateDates_Limit12_Offset0_Factor1(t *testing.T) {
-	t.Parallel()
-	repo := &repository{cfg: &Config{
-		GlobalAggregationInterval: struct {
-			Parent stdlibtime.Duration `yaml:"parent"`
-			Child  stdlibtime.Duration `yaml:"child"`
-		}{
-			Parent: 24 * stdlibtime.Hour,
-			Child:  stdlibtime.Hour,
-		},
-	}}
-	limit := uint64(12)
-	offset := uint64(0)
-	start := time.New(stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC))
-	end := time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, stdlibtime.UTC))
-	factor := stdlibtime.Duration(1)
-
-	dates, notBeforeTime, notAfterTime := repo.calculateDates(limit, offset, start, end, factor)
-	assert.Len(t, dates, 0)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC)), notBeforeTime)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC)), notAfterTime) // Cuz calculated limit is 0.
-
-	assert.Empty(t, dates)
-}
-
-func TestCalculateDates_Limit36_Offset0_Factor1(t *testing.T) {
-	repo := &repository{cfg: &Config{
-		GlobalAggregationInterval: struct {
-			Parent stdlibtime.Duration `yaml:"parent"`
-			Child  stdlibtime.Duration `yaml:"child"`
-		}{
-			Parent: 24 * stdlibtime.Hour,
-			Child:  stdlibtime.Hour,
-		},
-	}}
-
-	limit := uint64(36)
-	offset := uint64(0)
-	start := time.New(stdlibtime.Date(2023, 6, 5, 5, 15, 10, 1, stdlibtime.UTC))
-	end := time.New(stdlibtime.Date(2023, 6, 7, 5, 15, 10, 1, stdlibtime.UTC))
-	factor := stdlibtime.Duration(1)
-
-	dates, notBeforeTime, notAfterTime := repo.calculateDates(limit, offset, start, end, factor)
-	assert.Len(t, dates, 1)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC)), notBeforeTime)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, stdlibtime.UTC)), notAfterTime)
-
-	expectedStart := time.New(stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC))
-	expected := []stdlibtime.Time{
-		*expectedStart.Time,
-	}
-	assert.EqualValues(t, expected, dates)
-}
-
-func TestCalculateDates_Limit48_Offset0_Factor1(t *testing.T) {
-	repo := &repository{cfg: &Config{
-		GlobalAggregationInterval: struct {
-			Parent stdlibtime.Duration `yaml:"parent"`
-			Child  stdlibtime.Duration `yaml:"child"`
-		}{
-			Parent: 24 * stdlibtime.Hour,
-			Child:  stdlibtime.Hour,
-		},
-	}}
-	limit := uint64(48)
-	offset := uint64(0)
-	start := time.New(stdlibtime.Date(2023, 6, 5, 5, 15, 10, 1, stdlibtime.UTC))
-	end := time.New(stdlibtime.Date(2023, 6, 6, 5, 15, 10, 1, stdlibtime.UTC))
-	factor := stdlibtime.Duration(1)
-
-	dates, notBeforeTime, notAfterTime := repo.calculateDates(limit, offset, start, end, factor)
-	assert.Len(t, dates, 2)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC)), notBeforeTime)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, stdlibtime.UTC)), notAfterTime)
-
-	expectedStart := time.New(stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC))
-	expected := []stdlibtime.Time{
-		*expectedStart.Time,
-		expectedStart.Add(1 * repo.cfg.GlobalAggregationInterval.Parent),
+		stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 10, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 11, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 12, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 13, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 14, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 15, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 16, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 17, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 18, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 19, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 20, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 21, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 22, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 23, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 24, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 25, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 26, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 27, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 28, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 29, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 30, 0, 0, 0, 0, stdlibtime.UTC),
 	}
 	assert.EqualValues(t, expected, dates)
 }
@@ -141,107 +84,51 @@ func TestCalculateDates_Limit24_Offset0_FactorMinus1(t *testing.T) {
 	}}
 	limit := uint64(24)
 	offset := uint64(0)
-	start := time.New(stdlibtime.Date(2023, 6, 5, 5, 15, 10, 1, stdlibtime.UTC))
-	var end *time.Time
+	start := time.New(stdlibtime.Date(2023, 6, 7, 5, 15, 10, 1, stdlibtime.UTC))
+	end := time.New(stdlibtime.Date(2023, 6, 6, 5, 15, 10, 1, stdlibtime.UTC))
 	factor := stdlibtime.Duration(-1)
 
 	dates, notBeforeTime, notAfterTime := repo.calculateDates(limit, offset, start, end, factor)
-	assert.Len(t, dates, 1)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, stdlibtime.UTC)), notBeforeTime)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC)), notAfterTime)
+	assert.Len(t, dates, 30)
+	assert.Equal(t, end, notBeforeTime)
+	assert.Equal(t, start, notAfterTime)
 
-	expectedStart := time.New(stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC))
 	expected := []stdlibtime.Time{
-		*expectedStart.Time,
+		stdlibtime.Date(2023, 6, 30, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 29, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 28, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 27, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 26, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 25, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 24, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 23, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 22, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 21, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 20, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 19, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 18, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 17, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 16, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 15, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 14, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 13, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 12, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 11, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 10, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, stdlibtime.UTC),
 	}
 	assert.EqualValues(t, expected, dates)
 }
 
-func TestCalculateDates_Limit24_Offset24_FactorMinus1(t *testing.T) {
-	repo := &repository{cfg: &Config{
-		GlobalAggregationInterval: struct {
-			Parent stdlibtime.Duration `yaml:"parent"`
-			Child  stdlibtime.Duration `yaml:"child"`
-		}{
-			Parent: 24 * stdlibtime.Hour,
-			Child:  stdlibtime.Hour,
-		},
-	}}
-	limit := uint64(24)
-	offset := uint64(24)
-	start := time.New(stdlibtime.Date(2023, 6, 5, 5, 15, 10, 1, stdlibtime.UTC))
-	var end *time.Time
-	factor := stdlibtime.Duration(-1)
-
-	dates, notBeforeTime, notAfterTime := repo.calculateDates(limit, offset, start, end, factor)
-	assert.Len(t, dates, 1)
-
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, stdlibtime.UTC)), notBeforeTime)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, stdlibtime.UTC)), notAfterTime)
-
-	expectedStart := time.New(stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC))
-	expected := []stdlibtime.Time{
-		expectedStart.Add(-1 * repo.cfg.GlobalAggregationInterval.Parent),
-	}
-	assert.EqualValues(t, expected, dates)
-}
-
-func TestCalculateDates_Limit24_Offset24_Factor1(t *testing.T) {
-	repo := &repository{cfg: &Config{
-		GlobalAggregationInterval: struct {
-			Parent stdlibtime.Duration `yaml:"parent"`
-			Child  stdlibtime.Duration `yaml:"child"`
-		}{
-			Parent: 24 * stdlibtime.Hour,
-			Child:  stdlibtime.Hour,
-		},
-	}}
-	limit := uint64(24)
-	offset := uint64(24)
-	start := time.New(stdlibtime.Date(2023, 6, 5, 5, 15, 10, 1, stdlibtime.UTC))
-	end := time.New(stdlibtime.Date(2023, 6, 7, 5, 15, 10, 1, stdlibtime.UTC))
-	factor := stdlibtime.Duration(1)
-
-	dates, notBeforeTime, notAfterTime := repo.calculateDates(limit, offset, start, end, factor)
-	assert.Len(t, dates, 1)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, stdlibtime.UTC)), notBeforeTime)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, stdlibtime.UTC)), notAfterTime)
-	expectedStart := time.New(stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC))
-	expected := []stdlibtime.Time{
-		expectedStart.Add(1 * repo.cfg.GlobalAggregationInterval.Parent),
-	}
-	assert.EqualValues(t, expected, dates)
-}
-
-func TestCalculateDates_Limit48_Offset48_FactorMinus1(t *testing.T) {
-	repo := &repository{cfg: &Config{
-		GlobalAggregationInterval: struct {
-			Parent stdlibtime.Duration `yaml:"parent"`
-			Child  stdlibtime.Duration `yaml:"child"`
-		}{
-			Parent: 24 * stdlibtime.Hour,
-			Child:  stdlibtime.Hour,
-		},
-	}}
-	limit := uint64(48)
-	offset := uint64(48)
-	start := time.New(stdlibtime.Date(2023, 6, 5, 5, 15, 10, 1, stdlibtime.UTC))
-	end := time.New(stdlibtime.Date(2023, 6, 5, 5, 15, 10, 1, stdlibtime.UTC))
-	factor := stdlibtime.Duration(-1)
-
-	dates, notBeforeTime, notAfterTime := repo.calculateDates(limit, offset, start, end, factor)
-	assert.Len(t, dates, 2)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, stdlibtime.UTC)), notBeforeTime)
-	assert.Equal(t, time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, stdlibtime.UTC)), notAfterTime)
-	expectedStart := time.New(stdlibtime.Date(2023, 6, 5, 0, 0, 0, 0, stdlibtime.UTC))
-	expected := []stdlibtime.Time{
-		expectedStart.Add(-2 * repo.cfg.GlobalAggregationInterval.Parent),
-		expectedStart.Add(-3 * repo.cfg.GlobalAggregationInterval.Parent),
-	}
-	assert.EqualValues(t, expected, dates)
-}
-
-func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
+func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 	t.Parallel()
 	repo := &repository{cfg: &Config{
 		GlobalAggregationInterval: struct {
@@ -253,6 +140,8 @@ func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
 		},
 	}}
 	now := time.New(stdlibtime.Date(2023, 6, 5, 5, 15, 10, 1, stdlibtime.UTC))
+	utcOffset := stdlibtime.Duration(0)
+	location := stdlibtime.FixedZone(utcOffset.String(), int(utcOffset.Seconds()))
 
 	/******************************************************************************************************************************************************
 		1. History - data from clickhouse.
@@ -292,23 +181,24 @@ func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
 	/******************************************************************************************************************************************************
 		2. Not before time is -10 days. Not after time = now. startDateIsBeforeEndDate = true.
 	******************************************************************************************************************************************************/
+
 	notBeforeTime := time.New(now.Add(-10 * repo.cfg.GlobalAggregationInterval.Parent))
 	notAfterTime := now
 	startDateIsBeforeEndDate := true
 
-	entries := repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime)
+	entries := repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
 	expected := []*BalanceHistoryEntry{
 		{
-			Time: stdlibtime.Date(2023, 5, 30, 0, 0, 0, 0, stdlibtime.UTC),
+			Time: stdlibtime.Date(2023, 5, 1, 0, 0, 0, 0, location),
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   -17.,
-				Amount:   "17.00",
+				amount:   8.,
+				Amount:   "8.00",
 				Bonus:    0.,
-				Negative: true,
+				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: stdlibtime.Date(2023, 5, 30, 0, 0, 0, 0, stdlibtime.UTC),
+					Time: stdlibtime.Date(2023, 5, 30, 0, 0, 0, 0, location),
 					Balance: &BalanceHistoryBalanceDiff{
 						amount:   -17.,
 						Amount:   "17.00",
@@ -317,19 +207,8 @@ func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   25,
-				Amount:   "25.00",
-				Bonus:    247.06,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, location),
 					Balance: &BalanceHistoryBalanceDiff{
 						amount:   25,
 						Amount:   "25.00",
@@ -341,16 +220,16 @@ func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
 			},
 		},
 		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   31.,
-				Amount:   "31.00",
-				Bonus:    24,
+				amount:   116,
+				Amount:   "116.00",
+				Bonus:    1350.0,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
 						amount:   31.,
 						Amount:   "31.00",
@@ -359,19 +238,8 @@ func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   32.,
-				Amount:   "32.00",
-				Bonus:    3.23,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: *time.New(stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
 						amount:   32.,
 						Amount:   "32.00",
@@ -380,19 +248,8 @@ func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   28.,
-				Amount:   "28.00",
-				Bonus:    -12.5,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: *time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
 						amount:   28.,
 						Amount:   "28.00",
@@ -401,19 +258,8 @@ func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   25.,
-				Amount:   "25.00",
-				Bonus:    -10.71,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: *time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
 						amount:   25.,
 						Amount:   "25.00",
@@ -434,19 +280,19 @@ func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
 	notAfterTime = time.New(now.Truncate(repo.cfg.GlobalAggregationInterval.Parent))
 	startDateIsBeforeEndDate = true
 
-	entries = repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime)
+	entries = repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
 	expected = []*BalanceHistoryEntry{
 		{
-			Time: *time.New(stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+			Time: stdlibtime.Date(2023, 5, 1, 0, 0, 0, 0, location),
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   25,
-				Amount:   "25.00",
-				Bonus:    247.06,
+				amount:   8.,
+				Amount:   "8.00",
+				Bonus:    0.,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, location),
 					Balance: &BalanceHistoryBalanceDiff{
 						amount:   25,
 						Amount:   "25.00",
@@ -458,16 +304,16 @@ func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
 			},
 		},
 		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   31.,
-				Amount:   "31.00",
-				Bonus:    24,
+				amount:   116,
+				Amount:   "116.00",
+				Bonus:    1350.0,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
 						amount:   31.,
 						Amount:   "31.00",
@@ -476,19 +322,8 @@ func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   32.,
-				Amount:   "32.00",
-				Bonus:    3.23,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: *time.New(stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
 						amount:   32.,
 						Amount:   "32.00",
@@ -497,19 +332,8 @@ func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   28.,
-				Amount:   "28.00",
-				Bonus:    -12.5,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: *time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
 						amount:   28.,
 						Amount:   "28.00",
@@ -518,19 +342,8 @@ func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   25.,
-				Amount:   "25.00",
-				Bonus:    -10.71,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: *time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
 						amount:   25.,
 						Amount:   "25.00",
@@ -543,9 +356,90 @@ func TestProcessBalanceHistory_ChildIsHour(t *testing.T) {
 		},
 	}
 	assert.EqualValues(t, expected, entries)
+
+	/******************************************************************************************************************************************************
+		3. Not before time is -5 hours. Not after time = now. startDateIsBeforeEndDate = false.
+	******************************************************************************************************************************************************/
+	startDateIsBeforeEndDate = false
+	entries = repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
+	expected = []*BalanceHistoryEntry{
+		{
+			Time: stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location),
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   116,
+				Amount:   "116.00",
+				Bonus:    1350.0,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   25.,
+						Amount:   "25.00",
+						Bonus:    -10.71,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   28.,
+						Amount:   "28.00",
+						Bonus:    -12.5,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   32.,
+						Amount:   "32.00",
+						Bonus:    3.23,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   31.,
+						Amount:   "31.00",
+						Bonus:    24,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 5, 1, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   8.,
+				Amount:   "8.00",
+				Bonus:    0.,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
+				{
+					Time: stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, location),
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   25,
+						Amount:   "25.00",
+						Bonus:    0,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+			},
+		},
+	}
+	assert.EqualValues(t, expected, entries)
 }
 
-func TestProcessBalanceHistory_ChildIsHour_TimeGrow(t *testing.T) {
+func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 	t.Parallel()
 	repo := &repository{cfg: &Config{
 		GlobalAggregationInterval: struct {
@@ -557,6 +451,8 @@ func TestProcessBalanceHistory_ChildIsHour_TimeGrow(t *testing.T) {
 		},
 	}}
 	now := time.New(stdlibtime.Date(2023, 6, 5, 5, 15, 10, 1, stdlibtime.UTC))
+	utcOffset := stdlibtime.Duration(0)
+	location := stdlibtime.FixedZone(utcOffset.String(), int(utcOffset.Seconds()))
 
 	/******************************************************************************************************************************************************
 		1. History - data from clickhouse.
@@ -589,98 +485,155 @@ func TestProcessBalanceHistory_ChildIsHour_TimeGrow(t *testing.T) {
 		},
 		{
 			CreatedAt:           time.New(now.Add(6 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  12.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(7 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  29.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(8 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  0.,
+			BalanceTotalSlashed: 5.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(9 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  0.,
+			BalanceTotalSlashed: 19.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(10 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  0.,
+			BalanceTotalSlashed: 20.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(11 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  13.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(12 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(13 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(14 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(15 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  5.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(16 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  20.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(17 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  25.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(18 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  30.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(19 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  28.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(20 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  32.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(21 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  31.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(22 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  25.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(23 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
 			BalanceTotalMinted:  0.,
 			BalanceTotalSlashed: 17.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(24 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(25 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  20.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(26 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(27 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  10.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(28 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  20.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(29 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  10.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(30 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  20.,
+			BalanceTotalSlashed: 0.,
 		},
 	}
 
 	/******************************************************************************************************************************************************
-		2. Not before time is now. Not after time = +4 hours. startDateIsBeforeEndDate = false.
+		2. request = 1 day. startDateIsBeforeEndDate = false.
 	******************************************************************************************************************************************************/
 	notBeforeTime := time.New(now.Truncate(repo.cfg.GlobalAggregationInterval.Parent))
-	notAfterTime := time.New(now.Add(4 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent))
-	startDateIsBeforeEndDate := true
+	notAfterTime := time.New(now.Add(1 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent))
+	startDateIsBeforeEndDate := false
 
-	entries := repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime)
+	entries := repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
 	expected := []*BalanceHistoryEntry{
 		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   25,
-				Amount:   "25.00",
+				amount:   410,
+				Amount:   "410.00",
 				Bonus:    0,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
 						amount:   25,
 						Amount:   "25.00",
 						Bonus:    0,
-						Negative: false,
-					},
-					TimeSeries: []*BalanceHistoryEntry{},
-				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   28.,
-				Amount:   "28.00",
-				Bonus:    12,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
-				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-					Balance: &BalanceHistoryBalanceDiff{
-						amount:   28.,
-						Amount:   "28.00",
-						Bonus:    12,
-						Negative: false,
-					},
-					TimeSeries: []*BalanceHistoryEntry{},
-				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   32.,
-				Amount:   "32.00",
-				Bonus:    14.29,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
-				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-					Balance: &BalanceHistoryBalanceDiff{
-						amount:   32.,
-						Amount:   "32.00",
-						Bonus:    14.29,
-						Negative: false,
-					},
-					TimeSeries: []*BalanceHistoryEntry{},
-				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   31.,
-				Amount:   "31.00",
-				Bonus:    -3.13,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
-				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-					Balance: &BalanceHistoryBalanceDiff{
-						amount:   31.,
-						Amount:   "31.00",
-						Bonus:    -3.13,
 						Negative: false,
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
@@ -690,85 +643,88 @@ func TestProcessBalanceHistory_ChildIsHour_TimeGrow(t *testing.T) {
 	}
 	assert.EqualValues(t, expected, entries)
 
+	/******************************************************************************************************************************************************
+		3. request = week. startDateIsBeforeEndDate = false.
+	******************************************************************************************************************************************************/
+	notBeforeTime = now
+	notAfterTime = time.New(now.Add(7 * repo.cfg.GlobalAggregationInterval.Parent))
 	startDateIsBeforeEndDate = false
-	entries = repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime)
+
+	entries = repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
 	expected = []*BalanceHistoryEntry{
 		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   31.,
-				Amount:   "31.00",
-				Bonus:    -3.13,
+				amount:   410,
+				Amount:   "410.00",
+				Bonus:    0,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: *time.New(stdlibtime.Date(2023, 6, 12, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
-						amount:   31.,
+						amount:   29.0,
+						Amount:   "29.00",
+						Bonus:    141.67,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 11, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   12.0,
+						Amount:   "12.00",
+						Bonus:    -52,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 10, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   25,
+						Amount:   "25.00",
+						Bonus:    -19.35,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   31.0,
 						Amount:   "31.00",
 						Bonus:    -3.13,
 						Negative: false,
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   32.,
-				Amount:   "32.00",
-				Bonus:    14.29,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: *time.New(stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
-						amount:   32.,
+						amount:   32.0,
 						Amount:   "32.00",
 						Bonus:    14.29,
 						Negative: false,
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   28.,
-				Amount:   "28.00",
-				Bonus:    12,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: *time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
-						amount:   28.,
+						amount:   28.0,
 						Amount:   "28.00",
 						Bonus:    12,
 						Negative: false,
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   25,
-				Amount:   "25.00",
-				Bonus:    0,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
 				{
-					Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, stdlibtime.UTC)).Time,
+					Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
-						amount:   25,
+						amount:   25.0,
 						Amount:   "25.00",
 						Bonus:    0,
 						Negative: false,
@@ -779,6 +735,606 @@ func TestProcessBalanceHistory_ChildIsHour_TimeGrow(t *testing.T) {
 		},
 	}
 	assert.EqualValues(t, expected, entries)
+
+	/******************************************************************************************************************************************************
+		5. request = month. startDateIsBeforeEndDate = false.
+	******************************************************************************************************************************************************/
+	notBeforeTime = now
+	notAfterTime = time.New(now.Add(30 * repo.cfg.GlobalAggregationInterval.Parent))
+	startDateIsBeforeEndDate = false
+
+	entries = repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
+	expected = []*BalanceHistoryEntry{
+		{
+			Time: *time.New(stdlibtime.Date(2023, 7, 1, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   75.0,
+				Amount:   "75.00",
+				Bonus:    -81.71,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
+				{
+					Time: *time.New(stdlibtime.Date(2023, 7, 5, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   20.0,
+						Amount:   "20.00",
+						Bonus:    100,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 7, 4, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   10.0,
+						Amount:   "10.00",
+						Bonus:    -50,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 7, 3, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   20.0,
+						Amount:   "20.00",
+						Bonus:    100,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 7, 2, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   10.0,
+						Amount:   "10.00",
+						Bonus:    -33.33,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 7, 1, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   15.0,
+						Amount:   "15.00",
+						Bonus:    -25.00,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   410,
+				Amount:   "410.00",
+				Bonus:    0,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 30, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   20.0,
+						Amount:   "20.00",
+						Bonus:    33.33,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 29, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   15.0,
+						Amount:   "15.00",
+						Bonus:    188.24,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 28, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   -17.0,
+						Amount:   "17.00",
+						Bonus:    -168,
+						Negative: true,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 27, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   25.0,
+						Amount:   "25.00",
+						Bonus:    -19.35,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 26, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   31.0,
+						Amount:   "31.00",
+						Bonus:    -3.13,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 25, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   32.0,
+						Amount:   "32.00",
+						Bonus:    14.29,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 24, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   28.0,
+						Amount:   "28.00",
+						Bonus:    -6.67,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 23, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   30.0,
+						Amount:   "30.00",
+						Bonus:    20,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 22, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   25.0,
+						Amount:   "25.00",
+						Bonus:    25,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 21, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   20.0,
+						Amount:   "20.00",
+						Bonus:    300,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 20, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   5.0,
+						Amount:   "5.00",
+						Bonus:    -66.67,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 19, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   15.0,
+						Amount:   "15.00",
+						Bonus:    -0,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 18, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   15.0,
+						Amount:   "15.00",
+						Bonus:    -0,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 17, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   15.0,
+						Amount:   "15.00",
+						Bonus:    15.38,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 16, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   13.0,
+						Amount:   "13.00",
+						Bonus:    165,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 15, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   -20.0,
+						Amount:   "20.00",
+						Bonus:    5.26,
+						Negative: true,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 14, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   -19.0,
+						Amount:   "19.00",
+						Bonus:    280,
+						Negative: true,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 13, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   -5.0,
+						Amount:   "5.00",
+						Bonus:    -117.24,
+						Negative: true,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 12, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   29.0,
+						Amount:   "29.00",
+						Bonus:    141.67,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 11, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   12.0,
+						Amount:   "12.00",
+						Bonus:    -52,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 10, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   25,
+						Amount:   "25.00",
+						Bonus:    -19.35,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   31.0,
+						Amount:   "31.00",
+						Bonus:    -3.13,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   32.0,
+						Amount:   "32.00",
+						Bonus:    14.29,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   28.0,
+						Amount:   "28.00",
+						Bonus:    12,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   25.0,
+						Amount:   "25.00",
+						Bonus:    0,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+			},
+		},
+	}
+	assert.EqualValues(t, expected, entries)
+}
+
+func TestProcessBalanceHistory_ChildIsHour_Location(t *testing.T) {
+	t.Parallel()
+	repo := &repository{cfg: &Config{
+		GlobalAggregationInterval: struct {
+			Parent stdlibtime.Duration `yaml:"parent"`
+			Child  stdlibtime.Duration `yaml:"child"`
+		}{
+			Parent: 24 * stdlibtime.Hour,
+			Child:  stdlibtime.Hour,
+		},
+	}}
+	now := time.New(stdlibtime.Date(2023, 6, 5, 5, 15, 10, 1, stdlibtime.UTC))
+	utcOffset := stdlibtime.Duration(3 * stdlibtime.Hour)
+	location := stdlibtime.FixedZone(utcOffset.String(), int(utcOffset.Seconds()))
+
+	/******************************************************************************************************************************************************
+		1. History - data from clickhouse.
+	******************************************************************************************************************************************************/
+	history := []*dwh.BalanceHistory{
+		{
+			CreatedAt:           time.New(now.Add(1 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  25.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(2 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  28.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(3 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  32.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(4 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  31.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(5 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  25.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(6 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  12.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(7 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  29.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(8 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  0.,
+			BalanceTotalSlashed: 5.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(9 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  0.,
+			BalanceTotalSlashed: 19.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(10 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  0.,
+			BalanceTotalSlashed: 20.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(11 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  13.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(12 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(13 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(14 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(15 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  5.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(16 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  20.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(17 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  25.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(18 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  30.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(19 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  28.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(20 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  32.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(21 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  31.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(22 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  25.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(23 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  0.,
+			BalanceTotalSlashed: 17.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(24 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(25 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  20.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(26 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(27 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  10.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(28 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  20.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(29 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  10.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(30 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent)),
+			BalanceTotalMinted:  20.,
+			BalanceTotalSlashed: 0.,
+		},
+	}
+
+	/******************************************************************************************************************************************************
+		3. request = week. startDateIsBeforeEndDate = false.
+	******************************************************************************************************************************************************/
+	notBeforeTime := now
+	notAfterTime := time.New(now.Add(7 * repo.cfg.GlobalAggregationInterval.Parent))
+	startDateIsBeforeEndDate := false
+
+	entries := repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
+	expected := []*BalanceHistoryEntry{
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   410,
+				Amount:   "410.00",
+				Bonus:    0,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 12, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   29.0,
+						Amount:   "29.00",
+						Bonus:    141.67,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 11, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   12.0,
+						Amount:   "12.00",
+						Bonus:    -52,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 10, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   25,
+						Amount:   "25.00",
+						Bonus:    -19.35,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   31.0,
+						Amount:   "31.00",
+						Bonus:    -3.13,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   32.0,
+						Amount:   "32.00",
+						Bonus:    14.29,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   28.0,
+						Amount:   "28.00",
+						Bonus:    12,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   25.0,
+						Amount:   "25.00",
+						Bonus:    0,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+			},
+		},
+	}
+	assert.EqualValues(t, expected, entries)
+
 }
 
 //nolint:lll // .
@@ -921,179 +1477,4 @@ func expectedEnhancedBlockchainStats(sourceStats *TotalCoinsSummary, totals floa
 	expected.Blockchain = totals
 
 	return &expected
-}
-
-func TestProcessBalanceHistory_ChildIsEqualToParent24H(t *testing.T) {
-	t.Parallel()
-	repo := &repository{cfg: &Config{
-		GlobalAggregationInterval: struct {
-			Parent stdlibtime.Duration `yaml:"parent"`
-			Child  stdlibtime.Duration `yaml:"child"`
-		}{
-			Parent: 24 * stdlibtime.Hour,
-			Child:  24 * stdlibtime.Hour,
-		},
-	}}
-	now := time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, stdlibtime.UTC))
-	history := []*dwh.BalanceHistory{
-		{
-			CreatedAt:           now,
-			BalanceTotalMinted:  25.,
-			BalanceTotalSlashed: 0.,
-		},
-		{
-			CreatedAt:           time.New(now.Add(-1 * repo.cfg.GlobalAggregationInterval.Child)),
-			BalanceTotalMinted:  28.,
-			BalanceTotalSlashed: 0.,
-		},
-		{
-			CreatedAt:           time.New(now.Add(-2 * repo.cfg.GlobalAggregationInterval.Child)),
-			BalanceTotalMinted:  28.,
-			BalanceTotalSlashed: 0.,
-		},
-	}
-
-	notBeforeTime := time.New(now.Add(-24 * repo.cfg.GlobalAggregationInterval.Child))
-	notAfterTime := now
-	startDateIsBeforeEndDate := true
-
-	entries := repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime)
-
-	expected := []*BalanceHistoryEntry{
-		{
-			Time: stdlibtime.Date(2023, 5, 30, 0, 0, 0, 0, stdlibtime.UTC),
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   28.,
-				Amount:   "28.00",
-				Bonus:    0.,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
-				{
-					Time: stdlibtime.Date(2023, 5, 30, 0, 0, 0, 0, stdlibtime.UTC),
-					Balance: &BalanceHistoryBalanceDiff{
-						amount:   28.,
-						Amount:   "28.00",
-						Negative: false,
-						Bonus:    0,
-					},
-					TimeSeries: []*BalanceHistoryEntry{},
-				},
-			},
-		},
-		{
-			Time: stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, stdlibtime.UTC),
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   28.,
-				Amount:   "28.00",
-				Bonus:    0.,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
-				{
-					Time: stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, stdlibtime.UTC),
-					Balance: &BalanceHistoryBalanceDiff{
-						amount:   28.,
-						Amount:   "28.00",
-						Negative: false,
-						Bonus:    0,
-					},
-					TimeSeries: []*BalanceHistoryEntry{},
-				},
-			},
-		},
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   25.,
-				Amount:   "25.00",
-				Bonus:    -10.71,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
-				{
-					Time: stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, stdlibtime.UTC),
-					Balance: &BalanceHistoryBalanceDiff{
-						amount:   25.,
-						Amount:   "25.00",
-						Negative: false,
-						Bonus:    -10.71,
-					},
-					TimeSeries: []*BalanceHistoryEntry{},
-				},
-			},
-		},
-	}
-	assert.EqualValues(t, expected, entries)
-
-	startDateIsBeforeEndDate = false
-	entries = repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime)
-
-	expected = []*BalanceHistoryEntry{
-		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, stdlibtime.UTC)).Time,
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   25.,
-				Amount:   "25.00",
-				Bonus:    -10.71,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
-				{
-					Time: stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, stdlibtime.UTC),
-					Balance: &BalanceHistoryBalanceDiff{
-						amount:   25.,
-						Amount:   "25.00",
-						Negative: false,
-						Bonus:    -10.71,
-					},
-					TimeSeries: []*BalanceHistoryEntry{},
-				},
-			},
-		},
-		{
-			Time: stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, stdlibtime.UTC),
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   28.,
-				Amount:   "28.00",
-				Bonus:    0.,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
-				{
-					Time: stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, stdlibtime.UTC),
-					Balance: &BalanceHistoryBalanceDiff{
-						amount:   28.,
-						Amount:   "28.00",
-						Negative: false,
-						Bonus:    0,
-					},
-					TimeSeries: []*BalanceHistoryEntry{},
-				},
-			},
-		},
-		{
-			Time: stdlibtime.Date(2023, 5, 30, 0, 0, 0, 0, stdlibtime.UTC),
-			Balance: &BalanceHistoryBalanceDiff{
-				amount:   28.,
-				Amount:   "28.00",
-				Bonus:    0.,
-				Negative: false,
-			},
-			TimeSeries: []*BalanceHistoryEntry{
-				{
-					Time: stdlibtime.Date(2023, 5, 30, 0, 0, 0, 0, stdlibtime.UTC),
-					Balance: &BalanceHistoryBalanceDiff{
-						amount:   28.,
-						Amount:   "28.00",
-						Negative: false,
-						Bonus:    0,
-					},
-					TimeSeries: []*BalanceHistoryEntry{},
-				},
-			},
-		},
-	}
-
-	assert.EqualValues(t, expected, entries)
 }

--- a/tokenomics/contract.go
+++ b/tokenomics/contract.go
@@ -263,15 +263,15 @@ type (
 // Private API.
 
 const (
-	applicationYamlKey                  = "tokenomics"
-	dayFormat, hourFormat, minuteFormat = "2006-01-02", "2006-01-02T15", "2006-01-02T15:04"
-	totalActiveUsersGlobalKey           = "TOTAL_ACTIVE_USERS"
-	requestingUserIDCtxValueKey         = "requestingUserIDCtxValueKey"
-	clientTypeCtxValueKey               = "clientTypeCtxValueKey"
-	userHashCodeCtxValueKey             = "userHashCodeCtxValueKey"
-	authorizationCtxValueKey            = "authorizationCtxValueKey"
-	xAccountMetadataCtxValueKey         = "xAccountMetadataCtxValueKey"
-	requestDeadline                     = 25 * stdlibtime.Second
+	applicationYamlKey                               = "tokenomics"
+	monthFormat, dayFormat, hourFormat, minuteFormat = "2006-01", "2006-01-02", "2006-01-02T15", "2006-01-02T15:04"
+	totalActiveUsersGlobalKey                        = "TOTAL_ACTIVE_USERS"
+	requestingUserIDCtxValueKey                      = "requestingUserIDCtxValueKey"
+	clientTypeCtxValueKey                            = "clientTypeCtxValueKey"
+	userHashCodeCtxValueKey                          = "userHashCodeCtxValueKey"
+	authorizationCtxValueKey                         = "authorizationCtxValueKey"
+	xAccountMetadataCtxValueKey                      = "xAccountMetadataCtxValueKey"
+	requestDeadline                                  = 25 * stdlibtime.Second
 
 	floatToStringFormatter = "%.2f"
 

--- a/tokenomics/tokenomics.go
+++ b/tokenomics/tokenomics.go
@@ -344,7 +344,7 @@ func (c *Config) globalAggregationIntervalParentDateFormat() string {
 	case stdlibtime.Hour:
 		return hourFormat
 	case hoursInADay * stdlibtime.Hour:
-		return dayFormat
+		return monthFormat
 	default:
 		log.Panic(fmt.Sprintf("invalid interval: %v", c.GlobalAggregationInterval.Parent))
 


### PR DESCRIPTION
Balance history parent-child structure adopted to month-day durations. Production bounds (1 day, 1 week, 1 month) are done through start/end dates. Adoption of timezone location.