### PR TITLE
Balance history fixes (day format instead of month)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethereum/go-ethereum v1.14.7
 	github.com/goccy/go-json v0.10.3
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/ice-blockchain/eskimo v1.372.0
+	github.com/ice-blockchain/eskimo v1.373.0
 	github.com/ice-blockchain/go-tarantool-client v0.0.0-20230327200757-4fc71fa3f7bb
 	github.com/ice-blockchain/wintr v1.147.0
 	github.com/imroc/req/v3 v3.43.7

--- a/go.sum
+++ b/go.sum
@@ -303,8 +303,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/ice-blockchain/eskimo v1.372.0 h1:T5JfwtVMn3ep/1NW98sUZ99nRKOSKHgEUT+dtQk/T/w=
-github.com/ice-blockchain/eskimo v1.372.0/go.mod h1:etbbw8VRonltuR2fq4Rviput/FAItkatddbzj+eGxY8=
+github.com/ice-blockchain/eskimo v1.373.0 h1:JhW7fWXQz1Ju/q/78l4RxCA1elA1z+k557FFmtKhvnI=
+github.com/ice-blockchain/eskimo v1.373.0/go.mod h1:etbbw8VRonltuR2fq4Rviput/FAItkatddbzj+eGxY8=
 github.com/ice-blockchain/go-tarantool-client v0.0.0-20230327200757-4fc71fa3f7bb h1:8TnFP3mc7O+tc44kv2e0/TpZKnEVUaKH+UstwfBwRkk=
 github.com/ice-blockchain/go-tarantool-client v0.0.0-20230327200757-4fc71fa3f7bb/go.mod h1:ZsQU7i3mxhgBBu43Oev7WPFbIjP4TniN/b1UPNGbrq8=
 github.com/ice-blockchain/wintr v1.147.0 h1:VQxvK3FWFIbm+X6obrecx7n07cBZoQDf/dQX8gfCcTc=

--- a/tokenomics/balance_test.go
+++ b/tokenomics/balance_test.go
@@ -72,6 +72,243 @@ func TestCalculateDates_Factor1(t *testing.T) {
 	assert.EqualValues(t, expected, dates)
 }
 
+func TestCalculateDates_Staging_Factor1(t *testing.T) {
+	t.Parallel()
+	repo := &repository{cfg: &Config{
+		GlobalAggregationInterval: struct {
+			Parent stdlibtime.Duration `yaml:"parent"`
+			Child  stdlibtime.Duration `yaml:"child"`
+		}{
+			Parent: stdlibtime.Hour,
+			Child:  stdlibtime.Minute,
+		},
+	}}
+
+	limit := uint64(24)
+	offset := uint64(0)
+	start := time.New(stdlibtime.Date(2023, 6, 6, 5, 15, 10, 1, stdlibtime.UTC))
+	end := time.New(stdlibtime.Date(2023, 6, 6, 6, 15, 10, 1, stdlibtime.UTC))
+	factor := stdlibtime.Duration(1)
+
+	dates, notBeforeTime, notAfterTime := repo.calculateDates(limit, offset, start, end, factor)
+	assert.Len(t, dates, 120)
+	assert.Equal(t, start, notBeforeTime)
+	assert.Equal(t, end, notAfterTime)
+
+	expected := []stdlibtime.Time{
+		stdlibtime.Date(2023, 6, 6, 5, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 1, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 2, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 3, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 4, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 5, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 6, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 7, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 8, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 9, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 10, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 11, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 12, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 13, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 14, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 15, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 16, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 17, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 18, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 19, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 20, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 21, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 22, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 23, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 24, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 25, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 26, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 27, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 28, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 29, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 30, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 31, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 32, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 33, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 34, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 35, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 36, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 37, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 38, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 39, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 40, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 41, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 42, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 43, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 44, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 45, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 46, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 47, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 48, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 49, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 50, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 51, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 52, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 53, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 54, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 55, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 56, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 57, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 58, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 5, 59, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 1, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 2, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 3, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 4, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 5, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 6, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 7, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 8, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 9, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 10, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 11, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 12, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 13, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 14, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 15, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 16, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 17, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 18, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 19, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 20, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 21, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 22, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 23, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 24, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 25, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 26, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 27, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 28, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 29, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 30, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 31, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 32, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 33, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 34, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 35, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 36, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 37, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 38, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 39, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 40, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 41, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 42, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 43, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 44, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 45, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 46, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 47, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 48, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 49, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 50, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 51, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 52, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 53, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 54, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 55, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 56, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 57, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 58, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2023, 6, 6, 6, 59, 0, 0, stdlibtime.UTC),
+	}
+	assert.EqualValues(t, expected, dates)
+}
+
+func TestCalculateDates_Factor1_SeparateMonthes(t *testing.T) {
+	t.Parallel()
+	repo := &repository{cfg: &Config{
+		GlobalAggregationInterval: struct {
+			Parent stdlibtime.Duration `yaml:"parent"`
+			Child  stdlibtime.Duration `yaml:"child"`
+		}{
+			Parent: 24 * stdlibtime.Hour,
+			Child:  stdlibtime.Hour,
+		},
+	}}
+
+	limit := uint64(24)
+	offset := uint64(0)
+	start := time.New(stdlibtime.Date(2024, 7, 18, 12, 52, 32, 0, stdlibtime.UTC))
+	end := time.New(stdlibtime.Date(2024, 6, 18, 12, 52, 32, 0, stdlibtime.UTC))
+	factor := stdlibtime.Duration(1)
+
+	dates, notBeforeTime, notAfterTime := repo.calculateDates(limit, offset, start, end, factor)
+	assert.Len(t, dates, 61)
+	assert.Equal(t, start, notBeforeTime)
+	assert.Equal(t, end, notAfterTime)
+
+	expected := []stdlibtime.Time{
+		stdlibtime.Date(2024, 6, 1, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 2, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 3, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 4, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 5, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 6, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 7, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 8, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 9, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 10, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 11, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 12, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 13, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 14, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 15, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 16, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 17, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 18, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 19, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 20, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 21, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 22, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 23, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 24, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 25, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 26, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 27, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 28, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 29, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 6, 30, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 1, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 2, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 3, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 4, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 5, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 6, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 7, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 8, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 9, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 10, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 11, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 12, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 13, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 14, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 15, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 16, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 17, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 18, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 19, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 20, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 21, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 22, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 23, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 24, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 25, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 26, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 27, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 28, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 29, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 30, 0, 0, 0, 0, stdlibtime.UTC),
+		stdlibtime.Date(2024, 7, 31, 0, 0, 0, 0, stdlibtime.UTC),
+	}
+	assert.EqualValues(t, expected, dates)
+}
+
 func TestCalculateDates_Limit24_Offset0_FactorMinus1(t *testing.T) {
 	repo := &repository{cfg: &Config{
 		GlobalAggregationInterval: struct {
@@ -126,6 +363,32 @@ func TestCalculateDates_Limit24_Offset0_FactorMinus1(t *testing.T) {
 		stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, stdlibtime.UTC),
 	}
 	assert.EqualValues(t, expected, dates)
+}
+
+func TestCalculateDates_OffsetMore0(t *testing.T) {
+	t.Parallel()
+	repo := &repository{cfg: &Config{
+		GlobalAggregationInterval: struct {
+			Parent stdlibtime.Duration `yaml:"parent"`
+			Child  stdlibtime.Duration `yaml:"child"`
+		}{
+			Parent: 24 * stdlibtime.Hour,
+			Child:  stdlibtime.Hour,
+		},
+	}}
+
+	limit := uint64(24)
+	offset := uint64(24)
+	start := time.New(stdlibtime.Date(2023, 6, 6, 5, 15, 10, 1, stdlibtime.UTC))
+	end := time.New(stdlibtime.Date(2023, 6, 7, 5, 15, 10, 1, stdlibtime.UTC))
+	factor := stdlibtime.Duration(1)
+
+	dates, notBeforeTime, notAfterTime := repo.calculateDates(limit, offset, start, end, factor)
+	assert.Len(t, dates, 0)
+	assert.Nil(t, notBeforeTime)
+	assert.Nil(t, notAfterTime)
+
+	assert.Empty(t, dates)
 }
 
 func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
@@ -189,12 +452,12 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 	entries := repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
 	expected := []*BalanceHistoryEntry{
 		{
-			Time: stdlibtime.Date(2023, 5, 1, 0, 0, 0, 0, location),
+			Time: stdlibtime.Date(2023, 5, 30, 0, 0, 0, 0, location),
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   8.,
-				Amount:   "8.00",
+				amount:   -17.,
+				Amount:   "17.00",
 				Bonus:    0.,
-				Negative: false,
+				Negative: true,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
 				{
@@ -207,6 +470,17 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, location),
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   25,
+				Amount:   "25.00",
+				Bonus:    247.06,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, location),
 					Balance: &BalanceHistoryBalanceDiff{
@@ -222,9 +496,9 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 		{
 			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   116,
-				Amount:   "116.00",
-				Bonus:    1350.0,
+				amount:   31.,
+				Amount:   "31.00",
+				Bonus:    24,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
@@ -238,6 +512,17 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   32.,
+				Amount:   "32.00",
+				Bonus:    3.23,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -248,6 +533,17 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   28.,
+				Amount:   "28.00",
+				Bonus:    -12.5,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -258,6 +554,17 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   25.,
+				Amount:   "25.00",
+				Bonus:    -10.71,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -283,11 +590,11 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 	entries = repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
 	expected = []*BalanceHistoryEntry{
 		{
-			Time: stdlibtime.Date(2023, 5, 1, 0, 0, 0, 0, location),
+			Time: stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, location),
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   8.,
-				Amount:   "8.00",
-				Bonus:    0.,
+				amount:   25,
+				Amount:   "25.00",
+				Bonus:    247.06,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
@@ -306,9 +613,9 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 		{
 			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   116,
-				Amount:   "116.00",
-				Bonus:    1350.0,
+				amount:   31.,
+				Amount:   "31.00",
+				Bonus:    24,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
@@ -322,6 +629,17 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   32.,
+				Amount:   "32.00",
+				Bonus:    3.23,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -332,6 +650,17 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   28.,
+				Amount:   "28.00",
+				Bonus:    -12.5,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -342,6 +671,17 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   25.,
+				Amount:   "25.00",
+				Bonus:    -10.71,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -357,18 +697,18 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 	}
 	assert.EqualValues(t, expected, entries)
 
-	/******************************************************************************************************************************************************
-		3. Not before time is -5 hours. Not after time = now. startDateIsBeforeEndDate = false.
-	******************************************************************************************************************************************************/
+	// /******************************************************************************************************************************************************
+	// 	3. Not before time is -5 hours. Not after time = now. startDateIsBeforeEndDate = false.
+	// ******************************************************************************************************************************************************/
 	startDateIsBeforeEndDate = false
 	entries = repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
 	expected = []*BalanceHistoryEntry{
 		{
-			Time: stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location),
+			Time: *time.New(stdlibtime.Date(2023, 6, 4, 0, 0, 0, 0, location)).Time,
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   116,
-				Amount:   "116.00",
-				Bonus:    1350.0,
+				amount:   25.,
+				Amount:   "25.00",
+				Bonus:    -10.71,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
@@ -382,6 +722,17 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   28.,
+				Amount:   "28.00",
+				Bonus:    -12.5,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 3, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -392,6 +743,17 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   32.,
+				Amount:   "32.00",
+				Bonus:    3.23,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 2, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -402,6 +764,17 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   31.,
+				Amount:   "31.00",
+				Bonus:    24,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -415,11 +788,11 @@ func TestProcessBalanceHistory_ChildIsHour_AfterBeforeLimits(t *testing.T) {
 			},
 		},
 		{
-			Time: *time.New(stdlibtime.Date(2023, 5, 1, 0, 0, 0, 0, location)).Time,
+			Time: *time.New(stdlibtime.Date(2023, 5, 31, 0, 0, 0, 0, location)).Time,
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   8.,
-				Amount:   "8.00",
-				Bonus:    0.,
+				amount:   25,
+				Amount:   "25.00",
+				Bonus:    247.06,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
@@ -620,10 +993,10 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 	entries := repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
 	expected := []*BalanceHistoryEntry{
 		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
+			Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, location)).Time,
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   410,
-				Amount:   "410.00",
+				amount:   25,
+				Amount:   "25.00",
 				Bonus:    0,
 				Negative: false,
 			},
@@ -653,11 +1026,11 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 	entries = repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
 	expected = []*BalanceHistoryEntry{
 		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
+			Time: *time.New(stdlibtime.Date(2023, 6, 12, 0, 0, 0, 0, location)).Time,
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   410,
-				Amount:   "410.00",
-				Bonus:    0,
+				amount:   29.0,
+				Amount:   "29.00",
+				Bonus:    141.67,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
@@ -671,6 +1044,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 11, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   12.0,
+				Amount:   "12.00",
+				Bonus:    -52,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 11, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -681,6 +1065,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 10, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   25,
+				Amount:   "25.00",
+				Bonus:    -19.35,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 10, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -691,6 +1086,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   31.0,
+				Amount:   "31.00",
+				Bonus:    -3.13,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -701,6 +1107,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   32.0,
+				Amount:   "32.00",
+				Bonus:    14.29,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -711,6 +1128,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   28.0,
+				Amount:   "28.00",
+				Bonus:    12,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -721,6 +1149,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   25.0,
+				Amount:   "25.00",
+				Bonus:    0,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -736,9 +1175,9 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 	}
 	assert.EqualValues(t, expected, entries)
 
-	/******************************************************************************************************************************************************
-		5. request = month. startDateIsBeforeEndDate = false.
-	******************************************************************************************************************************************************/
+	// 	/******************************************************************************************************************************************************
+	// 		5. request = month. startDateIsBeforeEndDate = false.
+	// 	******************************************************************************************************************************************************/
 	notBeforeTime = now
 	notAfterTime = time.New(now.Add(30 * repo.cfg.GlobalAggregationInterval.Parent))
 	startDateIsBeforeEndDate = false
@@ -746,11 +1185,11 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 	entries = repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
 	expected = []*BalanceHistoryEntry{
 		{
-			Time: *time.New(stdlibtime.Date(2023, 7, 1, 0, 0, 0, 0, location)).Time,
+			Time: *time.New(stdlibtime.Date(2023, 7, 5, 0, 0, 0, 0, location)).Time,
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   75.0,
-				Amount:   "75.00",
-				Bonus:    -81.71,
+				amount:   20.0,
+				Amount:   "20.00",
+				Bonus:    100,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
@@ -764,6 +1203,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 7, 4, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   10.0,
+				Amount:   "10.00",
+				Bonus:    -50,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 7, 4, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -774,6 +1224,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 7, 3, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   20.0,
+				Amount:   "20.00",
+				Bonus:    100,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 7, 3, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -784,6 +1245,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 7, 2, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   10.0,
+				Amount:   "10.00",
+				Bonus:    -33.33,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 7, 2, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -794,6 +1266,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 7, 1, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   15.0,
+				Amount:   "15.00",
+				Bonus:    -25.00,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 7, 1, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -807,11 +1290,11 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 			},
 		},
 		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
+			Time: *time.New(stdlibtime.Date(2023, 6, 30, 0, 0, 0, 0, location)).Time,
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   410,
-				Amount:   "410.00",
-				Bonus:    0,
+				amount:   20.0,
+				Amount:   "20.00",
+				Bonus:    33.33,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
@@ -825,6 +1308,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 29, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   15.0,
+				Amount:   "15.00",
+				Bonus:    188.24,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 29, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -835,6 +1329,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 28, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   -17.0,
+				Amount:   "17.00",
+				Bonus:    -168,
+				Negative: true,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 28, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -845,6 +1350,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 27, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   25.0,
+				Amount:   "25.00",
+				Bonus:    -19.35,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 27, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -855,6 +1371,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 26, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   31.0,
+				Amount:   "31.00",
+				Bonus:    -3.13,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 26, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -865,6 +1392,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 25, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   32.0,
+				Amount:   "32.00",
+				Bonus:    14.29,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 25, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -875,6 +1413,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 24, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   28.0,
+				Amount:   "28.00",
+				Bonus:    -6.67,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 24, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -885,6 +1434,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 23, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   30.0,
+				Amount:   "30.00",
+				Bonus:    20,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 23, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -895,6 +1455,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 22, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   25.0,
+				Amount:   "25.00",
+				Bonus:    25,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 22, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -905,6 +1476,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 21, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   20.0,
+				Amount:   "20.00",
+				Bonus:    300,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 21, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -915,6 +1497,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 20, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   5.0,
+				Amount:   "5.00",
+				Bonus:    -66.67,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 20, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -925,6 +1518,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 19, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   15.0,
+				Amount:   "15.00",
+				Bonus:    -0,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 19, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -935,6 +1539,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 18, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   15.0,
+				Amount:   "15.00",
+				Bonus:    -0,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 18, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -945,6 +1560,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 17, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   15.0,
+				Amount:   "15.00",
+				Bonus:    15.38,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 17, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -955,6 +1581,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 16, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   13.0,
+				Amount:   "13.00",
+				Bonus:    165,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 16, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -965,6 +1602,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 15, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   -20.0,
+				Amount:   "20.00",
+				Bonus:    5.26,
+				Negative: true,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 15, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -975,6 +1623,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 14, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   -19.0,
+				Amount:   "19.00",
+				Bonus:    280,
+				Negative: true,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 14, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -985,6 +1644,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 13, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   -5.0,
+				Amount:   "5.00",
+				Bonus:    -117.24,
+				Negative: true,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 13, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -995,6 +1665,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 12, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   29.0,
+				Amount:   "29.00",
+				Bonus:    141.67,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 12, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -1005,6 +1686,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 11, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   12.0,
+				Amount:   "12.00",
+				Bonus:    -52,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 11, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -1015,6 +1707,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 10, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   25,
+				Amount:   "25.00",
+				Bonus:    -19.35,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 10, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -1025,6 +1728,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   31.0,
+				Amount:   "31.00",
+				Bonus:    -3.13,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -1035,6 +1749,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   32.0,
+				Amount:   "32.00",
+				Bonus:    14.29,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -1045,6 +1770,17 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   28.0,
+				Amount:   "28.00",
+				Bonus:    12,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -1055,12 +1791,319 @@ func TestProcessBalanceHistory_ChildIsHour_ProdLimits(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   25.0,
+				Amount:   "25.00",
+				Bonus:    0,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
 						amount:   25.0,
 						Amount:   "25.00",
 						Bonus:    0,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+			},
+		},
+	}
+
+	assert.EqualValues(t, expected, entries)
+}
+
+func TestProcessBalanceHistory_Staging(t *testing.T) {
+	t.Parallel()
+	repo := &repository{cfg: &Config{
+		GlobalAggregationInterval: struct {
+			Parent stdlibtime.Duration `yaml:"parent"`
+			Child  stdlibtime.Duration `yaml:"child"`
+		}{
+			Parent: stdlibtime.Hour,
+			Child:  stdlibtime.Minute,
+		},
+	}}
+	now := time.New(stdlibtime.Date(2023, 6, 5, 5, 15, 10, 1, stdlibtime.UTC))
+	utcOffset := stdlibtime.Duration(0)
+	location := stdlibtime.FixedZone(utcOffset.String(), int(utcOffset.Seconds()))
+
+	/******************************************************************************************************************************************************
+		1. History - data from clickhouse.
+	******************************************************************************************************************************************************/
+	history := []*dwh.BalanceHistory{
+		{
+			CreatedAt:           time.New(now.Add(1 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  25.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(2 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  28.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(3 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  32.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(4 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  31.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(5 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  25.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(6 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  12.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(7 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  29.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(8 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  0.,
+			BalanceTotalSlashed: 5.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(9 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  0.,
+			BalanceTotalSlashed: 19.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(10 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  0.,
+			BalanceTotalSlashed: 20.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(11 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  13.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(12 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(13 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(14 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(15 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  5.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(16 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  20.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(17 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  25.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(18 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  30.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(19 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  28.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(20 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  32.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(21 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  31.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(22 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  25.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(23 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  0.,
+			BalanceTotalSlashed: 17.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(24 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(25 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  20.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(26 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  15.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(27 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  10.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(28 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  20.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(29 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  10.,
+			BalanceTotalSlashed: 0.,
+		},
+		{
+			CreatedAt:           time.New(now.Add(30 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child)),
+			BalanceTotalMinted:  20.,
+			BalanceTotalSlashed: 0.,
+		},
+	}
+
+	/******************************************************************************************************************************************************
+		2. startDateIsBeforeEndDate = false.
+	******************************************************************************************************************************************************/
+	notBeforeTime := time.New(now.Truncate(repo.cfg.GlobalAggregationInterval.Parent))
+	notAfterTime := time.New(now.Add(10 * repo.cfg.GlobalAggregationInterval.Child).Truncate(repo.cfg.GlobalAggregationInterval.Child))
+	startDateIsBeforeEndDate := false
+
+	entries := repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
+	expected := []*BalanceHistoryEntry{
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 5, 5, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   485,
+				Amount:   "485.00",
+				Bonus:    0,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 5, 5, 25, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   -20,
+						Amount:   "20.00",
+						Bonus:    5.26,
+						Negative: true,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 5, 5, 24, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   -19,
+						Amount:   "19.00",
+						Bonus:    280,
+						Negative: true,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 5, 5, 23, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   -5,
+						Amount:   "5.00",
+						Bonus:    -117.24,
+						Negative: true,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 5, 5, 22, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   29,
+						Amount:   "29.00",
+						Bonus:    141.67,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 5, 5, 21, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   12,
+						Amount:   "12.00",
+						Bonus:    -52.0,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 5, 5, 20, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   25,
+						Amount:   "25.00",
+						Bonus:    -19.35,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 5, 5, 19, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   31,
+						Amount:   "31.00",
+						Bonus:    -3.13,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 5, 5, 18, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   32,
+						Amount:   "32.00",
+						Bonus:    14.29,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 5, 5, 17, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   28,
+						Amount:   "28.00",
+						Bonus:    12.,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 5, 5, 16, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   25,
+						Amount:   "25.00",
+						Bonus:    0.,
 						Negative: false,
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
@@ -1243,20 +2286,53 @@ func TestProcessBalanceHistory_ChildIsHour_Location(t *testing.T) {
 	}
 
 	/******************************************************************************************************************************************************
-		3. request = week. startDateIsBeforeEndDate = false.
+		2. request = 1 day. startDateIsBeforeEndDate = false.
 	******************************************************************************************************************************************************/
-	notBeforeTime := now
-	notAfterTime := time.New(now.Add(7 * repo.cfg.GlobalAggregationInterval.Parent))
+	notBeforeTime := time.New(now.Truncate(repo.cfg.GlobalAggregationInterval.Parent))
+	notAfterTime := time.New(now.Add(1 * repo.cfg.GlobalAggregationInterval.Parent).Truncate(repo.cfg.GlobalAggregationInterval.Parent))
 	startDateIsBeforeEndDate := false
 
 	entries := repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
 	expected := []*BalanceHistoryEntry{
 		{
-			Time: *time.New(stdlibtime.Date(2023, 6, 1, 0, 0, 0, 0, location)).Time,
+			Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, location)).Time,
 			Balance: &BalanceHistoryBalanceDiff{
-				amount:   410,
-				Amount:   "410.00",
+				amount:   25,
+				Amount:   "25.00",
 				Bonus:    0,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
+				{
+					Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, location)).Time,
+					Balance: &BalanceHistoryBalanceDiff{
+						amount:   25,
+						Amount:   "25.00",
+						Bonus:    0,
+						Negative: false,
+					},
+					TimeSeries: []*BalanceHistoryEntry{},
+				},
+			},
+		},
+	}
+	assert.EqualValues(t, expected, entries)
+
+	/******************************************************************************************************************************************************
+		3. request = week. startDateIsBeforeEndDate = false.
+	******************************************************************************************************************************************************/
+	notBeforeTime = now
+	notAfterTime = time.New(now.Add(7 * repo.cfg.GlobalAggregationInterval.Parent))
+	startDateIsBeforeEndDate = false
+
+	entries = repo.processBalanceHistory(history, startDateIsBeforeEndDate, notBeforeTime, notAfterTime, utcOffset)
+	expected = []*BalanceHistoryEntry{
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 12, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   29.0,
+				Amount:   "29.00",
+				Bonus:    141.67,
 				Negative: false,
 			},
 			TimeSeries: []*BalanceHistoryEntry{
@@ -1270,6 +2346,17 @@ func TestProcessBalanceHistory_ChildIsHour_Location(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 11, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   12.0,
+				Amount:   "12.00",
+				Bonus:    -52,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 11, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -1280,6 +2367,17 @@ func TestProcessBalanceHistory_ChildIsHour_Location(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 10, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   25,
+				Amount:   "25.00",
+				Bonus:    -19.35,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 10, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -1290,6 +2388,17 @@ func TestProcessBalanceHistory_ChildIsHour_Location(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   31.0,
+				Amount:   "31.00",
+				Bonus:    -3.13,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 9, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -1300,6 +2409,17 @@ func TestProcessBalanceHistory_ChildIsHour_Location(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   32.0,
+				Amount:   "32.00",
+				Bonus:    14.29,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 8, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -1310,6 +2430,17 @@ func TestProcessBalanceHistory_ChildIsHour_Location(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   28.0,
+				Amount:   "28.00",
+				Bonus:    12,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 7, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -1320,6 +2451,17 @@ func TestProcessBalanceHistory_ChildIsHour_Location(t *testing.T) {
 					},
 					TimeSeries: []*BalanceHistoryEntry{},
 				},
+			},
+		},
+		{
+			Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, location)).Time,
+			Balance: &BalanceHistoryBalanceDiff{
+				amount:   25.0,
+				Amount:   "25.00",
+				Bonus:    0,
+				Negative: false,
+			},
+			TimeSeries: []*BalanceHistoryEntry{
 				{
 					Time: *time.New(stdlibtime.Date(2023, 6, 6, 0, 0, 0, 0, location)).Time,
 					Balance: &BalanceHistoryBalanceDiff{
@@ -1334,7 +2476,6 @@ func TestProcessBalanceHistory_ChildIsHour_Location(t *testing.T) {
 		},
 	}
 	assert.EqualValues(t, expected, entries)
-
 }
 
 //nolint:lll // .

--- a/tokenomics/contract.go
+++ b/tokenomics/contract.go
@@ -263,15 +263,15 @@ type (
 // Private API.
 
 const (
-	applicationYamlKey                               = "tokenomics"
-	monthFormat, dayFormat, hourFormat, minuteFormat = "2006-01", "2006-01-02", "2006-01-02T15", "2006-01-02T15:04"
-	totalActiveUsersGlobalKey                        = "TOTAL_ACTIVE_USERS"
-	requestingUserIDCtxValueKey                      = "requestingUserIDCtxValueKey"
-	clientTypeCtxValueKey                            = "clientTypeCtxValueKey"
-	userHashCodeCtxValueKey                          = "userHashCodeCtxValueKey"
-	authorizationCtxValueKey                         = "authorizationCtxValueKey"
-	xAccountMetadataCtxValueKey                      = "xAccountMetadataCtxValueKey"
-	requestDeadline                                  = 25 * stdlibtime.Second
+	applicationYamlKey                  = "tokenomics"
+	dayFormat, hourFormat, minuteFormat = "2006-01-02", "2006-01-02T15", "2006-01-02T15:04"
+	totalActiveUsersGlobalKey           = "TOTAL_ACTIVE_USERS"
+	requestingUserIDCtxValueKey         = "requestingUserIDCtxValueKey"
+	clientTypeCtxValueKey               = "clientTypeCtxValueKey"
+	userHashCodeCtxValueKey             = "userHashCodeCtxValueKey"
+	authorizationCtxValueKey            = "authorizationCtxValueKey"
+	xAccountMetadataCtxValueKey         = "xAccountMetadataCtxValueKey"
+	requestDeadline                     = 25 * stdlibtime.Second
 
 	floatToStringFormatter = "%.2f"
 

--- a/tokenomics/tokenomics.go
+++ b/tokenomics/tokenomics.go
@@ -344,7 +344,7 @@ func (c *Config) globalAggregationIntervalParentDateFormat() string {
 	case stdlibtime.Hour:
 		return hourFormat
 	case hoursInADay * stdlibtime.Hour:
-		return monthFormat
+		return dayFormat
 	default:
 		log.Panic(fmt.Sprintf("invalid interval: %v", c.GlobalAggregationInterval.Parent))
 


### PR DESCRIPTION
Using parent day format for balance history instead of month not to break the FE grid. Fixed different monthes dates calculation. Fixed offset loading. Fixed missed utc offset handling.
Added staging tests.